### PR TITLE
Twi matrix test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ CFLAGS = -Os -DF_CPU=$(F_CPU) -mmcu=$(MCU)
 LDFLAGS = -mmcu=$(MCU)
 FIRMWARE = imagen.hex
 
+# Objetos
+DRIVERS = $(BUILD_DIR)/gpio.o $(BUILD_DIR)/serial.o $(BUILD_DIR)/twi-master.o $(BUILD_DIR)/twi-slave.o $(BUILD_DIR)/matrix-keyboard.o
+UTILS = $(BUILD_DIR)/queue.o
+
 # Misc
 INCLUDE_DIR = ./include
 BUILD_DIR = build
@@ -76,6 +80,12 @@ matrix-keyboard-2: $(BUILD_DIR)/queue.o $(BUILD_DIR)/gpio.o $(BUILD_DIR)/serial.
 py-serial-test: $(BUILD_DIR)/gpio.o $(BUILD_DIR)/serial.o $(BUILD_DIR)/py_serial_test.o
 	$(LINK)
 
+communication-slave: $(BUILD_DIR)/gpio.o $(BUILD_DIR)/queue.o $(BUILD_DIR)/twi-slave.o $(BUILD_DIR)/matrix-keyboard.o $(BUILD_DIR)/communication-slave.o
+	$(LINK)
+
+communication-master: $(BUILD_DIR)/queue.o $(BUILD_DIR)/gpio.o $(BUILD_DIR)/twi-master.o $(BUILD_DIR)/serial.o $(BUILD_DIR)/matrix-keyboard.o $(BUILD_DIR)/communication-master.o
+	$(LINK)
+
 # Objetos:
 $(BUILD_DIR)/%.o: ./src/drivers/%.c
 	mkdir -p $(BUILD_DIR)
@@ -98,6 +108,14 @@ $(BUILD_DIR)/%.o: src/tests/unit/%.c
 	$(COMPILE)
 
 $(BUILD_DIR)/py_serial_test.o: src/tests/integration/serial/py_serial_test.c
+	mkdir -p $(BUILD_DIR)
+	$(COMPILE)
+
+$(BUILD_DIR)/communication-slave.o: src/tests/integration/communication/communication-slave.c
+	mkdir -p $(BUILD_DIR)
+	$(COMPILE)
+
+$(BUILD_DIR)/communication-master.o: src/tests/integration/communication/communication-master.c
 	mkdir -p $(BUILD_DIR)
 	$(COMPILE)
 

--- a/include/matrix-keyboard.h
+++ b/include/matrix-keyboard.h
@@ -12,6 +12,8 @@
 #define N_ROWS 2                        // outputs in the scan
 #define N_COLUMNS 2                     // inputs in the scan
 #define N_INPUTS (N_ROWS * N_COLUMNS)   // Total number of inputs
+#define ROWS {5, 6}
+#define COLUMNS {8, 9}
 
 // FUNCTIONS
 

--- a/include/twi-common.h
+++ b/include/twi-common.h
@@ -24,7 +24,7 @@
 
 // VARIOS
 #define STATUS_REG_MASK 0xF8  // Máscara del registro de estado
-#define I2C_TRANSMISSION_COMPLETE (twi->twcr & (1 << TWINT))  // Verificar si la transmisión I2C está completa
+#define I2C_TRANSMISSION_COMPLETE (TWCR & (1 << TWINT))  // Verificar si la transmisión I2C está completa
 
 /**********************************************************************
  * ESTRUCTURA TWI

--- a/include/twi-master.h
+++ b/include/twi-master.h
@@ -6,7 +6,7 @@
 #define TWI_MASTER_H
 
 #include <stdint.h>
-#include <twi-common.h>
+#include "twi-common.h"
 
 
 /**********************************************************************
@@ -74,7 +74,7 @@ static void send_NACK(void);
 /**
  * @brief Inicializa el maestro TWI.
  */
-void master_init();
+void twi_master_init();
 
 /**
  * @brief Recibe un byte de datos desde un dispositivo esclavo TWI.
@@ -89,6 +89,6 @@ uint8_t twi_master_receive_byte(const uint8_t tx_sla);
  *
  * @return uint8_t Último byte de datos recibido.
  */
-uint8_t get_received_data();
+uint8_t twi_get_received_data();
 
 #endif //TWI_MASTER_H

--- a/include/twi-slave.h
+++ b/include/twi-slave.h
@@ -6,7 +6,7 @@
 #define TWI_SLAVE_H
 
 #include <stdint.h>
-#include <twi-common.h>
+#include "twi-common.h"
 
 /**********************************************************************
  * TWI FUNCTIONS
@@ -17,12 +17,12 @@
  *
  * @param sla Dirección del esclavo TWI.
  */
-void sla_slave_init(uint8_t sla);
+void twi_sla_slave_init(uint8_t sla);
 
 /**
  * @brief Inicializa el esclavo TWI.
  */
-void slave_init();
+void twi_slave_init();
 
 /**
  * @brief Transmite un byte de datos desde el esclavo TWI.

--- a/src/drivers/matrix-keyboard.c
+++ b/src/drivers/matrix-keyboard.c
@@ -7,8 +7,8 @@
 
 // VARIABLES
 
-uint8_t rows[N_ROWS] = {5, 6};
-uint8_t columns[N_COLUMNS] = {2, 3};
+uint8_t rows[N_ROWS] = ROWS;
+uint8_t columns[N_COLUMNS] = COLUMNS;
 uint8_t inputs_state[N_INPUTS];
 queue *toggle_events;
 

--- a/src/drivers/twi-master.c
+++ b/src/drivers/twi-master.c
@@ -4,9 +4,9 @@
 
 #include <stdint.h>
 #include <util/twi.h>
-#include <twi-master.h>
+#include "twi-master.h"
 
-twi_t *twi = (twi_t *) (0xB8);
+twi_t *twi_master = (twi_t *) (0xB8);
 
 /**********************************************************************
  * RECEIVED DATA STORAGE
@@ -14,7 +14,7 @@ twi_t *twi = (twi_t *) (0xB8);
 
 uint8_t twi_received_byte;
 
-uint8_t get_received_data() {
+uint8_t twi_get_received_data() {
     return twi_received_byte;
 }
 
@@ -22,10 +22,10 @@ uint8_t get_received_data() {
  * TWI FUNCTIONS
  **********************************************************************/
 
-void master_init() {
-    twi->twsr = PRESCALER_1;
-    twi->twbr = ((F_MASTER / F_I2C) - 16) / 2;
-    twi->twcr = ENABLE_TWI;
+void twi_master_init() {
+    twi_master->twsr = PRESCALER_1;
+    twi_master->twbr = ((F_MASTER / F_I2C) - 16) / 2;
+    twi_master->twcr = ENABLE_TWI;
 }
 
 uint8_t twi_master_receive_byte(const uint8_t tx_sla) {
@@ -46,7 +46,7 @@ uint8_t twi_master_receive_byte(const uint8_t tx_sla) {
     } while (1);
 
     send_NACK();
-    twi_received_byte = twi->twdr;
+    twi_received_byte = twi_master->twdr;
     twi_stop();
     return 0;
 }
@@ -71,37 +71,37 @@ static void delay_us(int us) {
 }
 
 static uint8_t get_status(void) {
-    return twi->twsr & STATUS_REG_MASK;
+    return twi_master->twsr & STATUS_REG_MASK;
 }
 
 static uint8_t twi_start(void) {
     delay_us(10);
-    twi->twcr = CLEAR_INT | GEN_START | ENABLE_TWI;
+    twi_master->twcr = CLEAR_INT | GEN_START | ENABLE_TWI;
     while (!I2C_TRANSMISSION_COMPLETE)
         ;
     return get_status();
 }
 
 static void twi_stop(void) {
-    twi->twcr = GEN_STOP | CLEAR_INT | ENABLE_TWI;
+    twi_master->twcr = GEN_STOP | CLEAR_INT | ENABLE_TWI;
 }
 
 static uint8_t transmit(const uint8_t data) {
-    twi->twdr = data;
-    twi->twcr = CLEAR_INT | ENABLE_TWI;
+    twi_master->twdr = data;
+    twi_master->twcr = CLEAR_INT | ENABLE_TWI;
     while (!I2C_TRANSMISSION_COMPLETE)
         ;
     return get_status();
 }
 
 static void send_ACK() {
-    twi->twcr = CLEAR_INT | ENABLE_TWI | ENABLE_ACK;
+    twi_master->twcr = CLEAR_INT | ENABLE_TWI | ENABLE_ACK;
     while (!I2C_TRANSMISSION_COMPLETE)
         ;
 }
 
 static void send_NACK() {
-    twi->twcr = CLEAR_INT | ENABLE_TWI;
+    twi_master->twcr = CLEAR_INT | ENABLE_TWI;
     while (!I2C_TRANSMISSION_COMPLETE)
         ;
 }

--- a/src/drivers/twi-slave.c
+++ b/src/drivers/twi-slave.c
@@ -4,21 +4,21 @@
 
 #include <stdint.h>
 #include <util/twi.h>
-#include <twi-slave.h>
+#include "twi-slave.h"
 
-twi_t *twi = (twi_t *) (0xB8);
+twi_t *twi_slave = (twi_t *) (0xB8);
 
 /**********************************************************************
  * TWI FUNCTIONS
  **********************************************************************/
 
-void sla_slave_init(const uint8_t sla) {
-    twi->twar = sla << TWA0;
-    twi->twcr = ENABLE_TWI | ENABLE_ACK;
+void twi_sla_slave_init(const uint8_t sla) {
+    twi_slave->twar = sla << TWA0;
+    twi_slave->twcr = ENABLE_TWI | ENABLE_ACK;
 }
 
-void slave_init() {
-    sla_slave_init(DEFAULT_SLA);
+void twi_slave_init() {
+    twi_sla_slave_init(DEFAULT_SLA);
 }
 
 uint8_t twi_slave_transmit(const uint8_t data) {
@@ -33,7 +33,7 @@ uint8_t twi_slave_transmit(const uint8_t data) {
     if (status != TW_ST_DATA_NACK)
         return status;
 
-    twi->twcr = CLEAR_INT | ENABLE_TWI | ENABLE_ACK;    // Slave last action
+    twi_slave->twcr = CLEAR_INT | ENABLE_TWI | ENABLE_ACK;    // Slave last action
     return 0;
 }
 
@@ -42,12 +42,12 @@ uint8_t twi_slave_transmit(const uint8_t data) {
  **********************************************************************/
 
 static uint8_t get_status(void) {
-    return twi->twsr & STATUS_REG_MASK;
+    return twi_slave->twsr & STATUS_REG_MASK;
 }
 
 static uint8_t transmit(const uint8_t data) {
-    twi->twdr = data;
-    twi->twcr = CLEAR_INT | ENABLE_TWI;
+    twi_slave->twdr = data;
+    twi_slave->twcr = CLEAR_INT | ENABLE_TWI;
     while (!I2C_TRANSMISSION_COMPLETE)
         ;
     return get_status();

--- a/src/tests/integration/communication/communication-master.c
+++ b/src/tests/integration/communication/communication-master.c
@@ -1,0 +1,33 @@
+//
+// Created by dario on 30/12/24.
+//
+
+#include <stdint.h>
+
+#include "twi-master.h"
+#include "matrix-keyboard.h"
+#include "serial.h"
+
+
+void main() {
+
+    master_init();
+    serial_init();
+
+    uint8_t buttons[N_INPUTS];
+    for (int i = 0; i < N_INPUTS; i++) {
+        buttons[i] = 0;
+    }
+
+    while (1) {
+        twi_master_receive_byte(DEFAULT_SLA);
+        const uint8_t change = get_received_data();
+        buttons[change] = !buttons[change];
+
+        for (int i = 0; i < N_INPUTS; i++) {
+            serial_put_int(buttons[i], 1);
+            serial_put_str(" ");
+        }
+        serial_put_str("\r");
+    }
+}

--- a/src/tests/integration/communication/communication-master.c
+++ b/src/tests/integration/communication/communication-master.c
@@ -11,7 +11,7 @@
 
 void main() {
 
-    master_init();
+    twi_master_init();
     serial_init();
 
     uint8_t buttons[N_INPUTS];
@@ -21,7 +21,7 @@ void main() {
 
     while (1) {
         twi_master_receive_byte(DEFAULT_SLA);
-        const uint8_t change = get_received_data();
+        const uint8_t change = twi_get_received_data();
         buttons[change] = !buttons[change];
 
         for (int i = 0; i < N_INPUTS; i++) {

--- a/src/tests/integration/communication/communication-slave.c
+++ b/src/tests/integration/communication/communication-slave.c
@@ -1,0 +1,25 @@
+//
+// Created by dario on 30/12/24.
+//
+
+#include "twi-slave.h"
+#include "matrix-keyboard.h"
+
+void main() {
+
+    matrix_init();
+    slave_init();
+    queue *data = get_toggle_events();
+
+    while (1) {
+        scan();
+        if (is_empty(data)) {
+            twi_slave_transmit(-1);
+            continue;
+        }
+        do {
+            twi_slave_transmit(dequeue(data));
+        } while (!is_empty(data));
+
+    }
+}

--- a/src/tests/integration/communication/communication-slave.c
+++ b/src/tests/integration/communication/communication-slave.c
@@ -8,7 +8,7 @@
 void main() {
 
     matrix_init();
-    slave_init();
+    twi_slave_init();
     queue *data = get_toggle_events();
 
     while (1) {

--- a/src/tests/unit/twi/twi_master_test.c
+++ b/src/tests/unit/twi/twi_master_test.c
@@ -4,14 +4,14 @@
 #include "twi-master.h"
 
 int main(void) {
-    master_init();
+    twi_master_init();
     uint8_t data = 0;
     gpio_output(13);
     gpio_pin(13, OFF);
 
     while (1) {
         twi_master_receive_byte(DEFAULT_SLA);
-        data = get_received_data();
+        data = twi_get_received_data();
         if (data == 0) {
             gpio_pin(13, OFF);
         } else {

--- a/src/tests/unit/twi/twi_slave_test.c
+++ b/src/tests/unit/twi/twi_slave_test.c
@@ -3,7 +3,7 @@
 
 int main(void) {
     gpio_input(13);
-    slave_init(0);
+    twi_slave_init();
     twi_slave_transmit(1);
     twi_slave_transmit(0);
     while (1) {


### PR DESCRIPTION
### Funcionalidad principal

Se agrega un test que permite recibir eventos de un teclado matricial. El teclado está conectado en un dispositivo esclavo y los eventos se reciben en un maestro que está conectado al esclavo utilizando comunicación I²C. El esclavo loggea en la terminal via comunicación serial el estado en tiempo real de cada pulsador.

### Cambios menores

- Se agregan las variables `DRIVERS` y `UTILS` al archivo Makefile para reducir la longitud de los requisitos de los targets.
- Se añade el prefijo `twi` a las funciones no estáticas de los módulos TWI.

#### Trabajo restante
- [ ] Escribir la documentación correspondiente del nuevo test (con diagarama de conexión).
- [ ] Agregar una etapa extra de comunicación que permita enviar el estado de los pulsadores a un script de python.